### PR TITLE
Fix bootRun instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,6 @@ cd be
 chmod +x gradlew
 
 # Run the app
-override
 ./gradlew bootRun
 ```
 


### PR DESCRIPTION
## Summary
- remove stray `override` line from Gradle bootRun instructions

## Testing
- `npm test` *(fails: Error: no test specified)*
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_b_6887a37fde748329b1a9e1bdd56efd38